### PR TITLE
optimize: cache menubuttons enum

### DIFF
--- a/src/Hooks/RunCommand.cs
+++ b/src/Hooks/RunCommand.cs
@@ -14,6 +14,8 @@ internal static class RunCommandHook
             : "40 53 56 57 48 81 EC 80 00 00 00 0F"
     );
 
+    private static readonly MenuButton[] _menuButtons = Enum.GetValues<MenuButton>();
+
     public static void Register() => _runCommand.Hook(RunCommandPre, HookMode.Pre);
 
     private static unsafe HookResult RunCommandPre(DynamicHook h)
@@ -43,19 +45,17 @@ internal static class RunCommandHook
 
         ulong buttons = userCmd->ButtonState.PressedButtons | userCmd->ButtonState.ScrollButtons;
 
-        foreach (MenuButton button in Enum.GetValues(typeof(MenuButton)))
+        for (int i = 0; i < _menuButtons.Length; i++)
         {
-            if ((buttons & menu.Options.Buttons[button]) == menu.Options.Buttons[button])
-            {
-                if (
-                    menu.InputDelay[(int)button] + menu.Options.ButtonsDelay
-                    > Environment.TickCount64
-                )
-                {
-                    continue;
-                }
+            MenuButton button = _menuButtons[i];
+            ulong buttonMask = menu.Options.Buttons[button];
 
-                menu.InputDelay[(int)button] = Environment.TickCount64;
+            if (
+                (buttons & buttonMask) == buttonMask
+                && menu.InputDelay[i] + menu.Options.ButtonsDelay <= Environment.TickCount64
+            )
+            {
+                menu.InputDelay[i] = Environment.TickCount64;
                 menu.Input(player, button);
             }
         }

--- a/src/MenuBase.cs
+++ b/src/MenuBase.cs
@@ -9,9 +9,9 @@ public class MenuBase
     public MenuOptions Options { get; init; }
     public List<MenuValue>? Header { get; set; }
     public List<MenuValue>? Footer { get; set; }
-    public Action<CCSPlayerController, MenuBase, MenuAction>? Callback { get; set; }
     public List<MenuItem> Items { get; set; } = [];
     public (int Index, MenuItem Item)? SelectedItem { get; set; } = null;
+    public Action<CCSPlayerController, MenuBase, MenuAction>? Callback { get; set; }
     public bool Text { get; set; } = false;
 
     public MenuBase(MenuValue? header = null, MenuValue? footer = null, MenuOptions? options = null)
@@ -59,9 +59,9 @@ public class MenuBase
                     return;
                 }
 
-                for (int newIdx = SelectedItem.Value.Index - 1; newIdx >= 0; newIdx--)
+                for (int newIndex = SelectedItem.Value.Index - 1; newIndex >= 0; newIndex--)
                 {
-                    if (SelectItem(newIdx))
+                    if (SelectItem(newIndex))
                     {
                         Callback?.Invoke(player, this, MenuAction.Update);
                         break;
@@ -76,9 +76,9 @@ public class MenuBase
                     return;
                 }
 
-                for (int newIdx = SelectedItem.Value.Index + 1; newIdx < Items.Count; newIdx++)
+                for (int newIndex = SelectedItem.Value.Index + 1; newIndex < Items.Count; newIndex++)
                 {
-                    if (SelectItem(newIdx))
+                    if (SelectItem(newIndex))
                     {
                         Callback?.Invoke(player, this, MenuAction.Update);
                         break;
@@ -117,6 +117,7 @@ public class MenuBase
         }
     }
 
+    [Obsolete("Use MenuBase.Items.Add() (List<MenuItem>)")]
     public void AddItem(MenuItem item) => Items.Add(item);
 
     private bool SelectItem(int index) =>

--- a/src/MenuMethods.cs
+++ b/src/MenuMethods.cs
@@ -15,10 +15,14 @@ public static partial class Menu
 
         for (int i = 0; i < menu.Items.Count; i++)
         {
-            if (MenuBase.IsSelectable(menu.Items[i]))
+            if (menu.Items[i]?.Values?[0] is MenuValue value && menu.Items[i].SelectedValue is null)
+            {
+                menu.Items[i].SelectedValue = (0, value);
+            }
+
+            if (MenuBase.IsSelectable(menu.Items[i]) && menu.SelectedItem is null)
             {
                 menu.SelectedItem = (i, menu.Items[i]);
-                break;
             }
         }
 
@@ -36,6 +40,8 @@ public static partial class Menu
                 _menus[player].Add(menu);
             }
         }
+
+        menu.Callback?.Invoke(player, menu, MenuAction.Start);
     }
 
     public static void Clear(CCSPlayerController player)

--- a/src/MenuOptions.cs
+++ b/src/MenuOptions.cs
@@ -49,12 +49,11 @@ public class MenuOptions
 
     public MenuInput<MenuButton> Buttons { get; set; } = new();
     public bool BlockMovement { get; set; } = false;
-    public bool ProcessInput { get; set; } = true;
     public int ButtonsDelay { get; set; } = 150;
     public bool DisplayItemsInHeader { get; set; } = true;
     public bool Exitable { get; set; } = true;
     public int Priority { get; set; } = 0;
-
+    public bool ProcessInput { get; set; } = true;
     //TODO
     public bool BlockJump { get; set; } = false;
     public int Timeout { get; set; } = 0;
@@ -86,10 +85,4 @@ public class MenuOptions
         new("[ ", new Color().Rainbow()),
         new(" ]", new Color().Rainbow()),
     ];
-
-    public MenuValue[] Bool = [new("✘", Color.Red), new("✔", Color.Green)];
-
-    public MenuValue[] Slider = [new("("), new(")"), new("-"), new("|")];
-
-    public MenuValue Input = new("________", Color.White);
 }


### PR DESCRIPTION
obsolete: MenuBase.AddItem()
fix: default selected items & values
feat: MenuAction.Start